### PR TITLE
Validation of moroccan ICE company numbers #1

### DIFF
--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,0 +1,36 @@
+// TODO This is for companies
+export enum ICEErrorCode {
+  INVALID_INPUT = 'INVALID_INPUT',
+  INVALID_FORMAT = 'INVALID_FORMAT',
+  INVALID_SEQUENCE = 'INVALID_SEQUENCE',
+  PARTIALLY_VALID = 'PARTIALLY_VALID',
+}
+
+/**
+ * Represents an error that occurred during CIN validation
+ */
+export interface ICEError {
+  /** The type of error that occurred */
+  code: ICEErrorCode;
+  /** Detailed error message */
+  message: string;
+}
+
+/**
+ * Result of validating a CIN
+ */
+export interface ICEValidationResult {
+  /** Whether the ICE is valid */
+  isValid: boolean;
+  /** Array of validation errors if any */
+  errors: ICEError[];
+  /** Additional metadata extracted from the ICE */
+  metadata?: {
+    /** Company code */
+    company?: string;
+    /** Company's establishments */
+    establishments?: string;
+    /** Checksum for error detection */
+    checksum?: string;
+  };
+}

--- a/src/validators/company.ts
+++ b/src/validators/company.ts
@@ -1,0 +1,143 @@
+import { ICEErrorCode, ICEValidationResult } from '../types/company';
+
+// http://www.ompic.ma/fr/content/identifiant-commun-de-lentreprise
+// Identifiant Commun de l'Entreprise
+const ICE_REGEX = /^\d{15}$/;
+
+// TODO Numero de registre de commerce
+// TODO Identifiant fiscal
+// TODO Numero de CNSS
+
+/**
+ * Sanitizes an ICE input string by removing all non-digits characters
+ *
+ * @param input - Raw ICE input that needs to be sanitized
+ * @returns Sanitized string of 15 digits or null if input is invalid
+ *
+ * @example
+ * ```typescript
+ * sanitizeICE('123456789000012'); // Returns '123456789000012'
+ * sanitizeICE('  123456789000012'); // Returns '123456789000012'
+ * sanitizeICE(null); // Returns null
+ * ```
+ */
+export function sanitizeICE(input: unknown): string | null {
+  if (typeof input !== 'string') {
+    return null;
+  }
+
+  return input.replace(/[^0-9]/g, '');
+  // ? Should we only remove whitespace and special characters, similar to CIN?
+  // return input.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+}
+
+/**
+ * Performs comprehensive validation of a Moroccan ICE (Identifiant Commun de l'Entreprise)
+ *
+ * @param ice - The ICE string to validate
+ * @returns Validation result containing status, errors, and metadata if valid
+ *
+ * @example
+ * ```typescript
+ * validateICE('123456789000057');
+ * // Returns {
+ * //   isValid: true,
+ * //   errors: [],
+ * //   metadata: {
+ * //     company: '123456789',
+ * //     establishments: '0000',
+ * //     checksum: '57',
+ * //   }
+ * // }
+ *
+ * validateICE('XX999999');
+ * // Returns {
+ * //   isValid: false,
+ * //   errors: [{
+ * //     code: ICEErrorCode.INVALID_ICE,
+ * //     message: 'Invalid ICE'
+ * //   }]
+ * // }
+ * ```
+ */
+export function validateICE(ice: unknown): ICEValidationResult {
+  const result: ICEValidationResult = {
+    isValid: false,
+    errors: [],
+  };
+
+  // Input validation
+  if (!ice || typeof ice !== 'string') {
+    result.errors.push({
+      code: ICEErrorCode.INVALID_INPUT,
+      message: 'ICE must be a non-empty string',
+    });
+    return result;
+  }
+
+  // Sanitize input
+  const sanitized = sanitizeICE(ice);
+  if (!sanitized) {
+    result.errors.push({
+      code: ICEErrorCode.INVALID_INPUT,
+      message: 'ICE contains invalid characters',
+    });
+    return result;
+  }
+
+  // Check format
+  if (!ICE_REGEX.test(sanitized)) {
+    result.errors.push({
+      code: ICEErrorCode.INVALID_FORMAT,
+      message: 'Invalid ICE format. Must be string of 15 digits',
+    });
+    return result;
+  }
+
+  // Extract and validate parts
+  const match = sanitized.match(/^(\d{9})(\d{4})(\d{2})$/);
+  if (match) {
+    const company = match[1];
+    const establishments = match[2];
+    const checksum = match[3];
+    console.log(`Company: ${company}`);
+    console.log(`Establishments: ${establishments}`);
+    console.log(`Checksum: ${checksum}`);
+
+    if (!/^\d{9}$/.test(company)) {
+      result.errors.push({
+        code: ICEErrorCode.INVALID_SEQUENCE,
+        message: 'Company must be 9 digits',
+      });
+      return result;
+    }
+
+    if (!/^\d{4}$/.test(establishments)) {
+      result.errors.push({
+        code: ICEErrorCode.INVALID_SEQUENCE,
+        message: 'Establishments must be 4 digits',
+      });
+      return result;
+    }
+
+    if (!/^\d{2}$/.test(checksum)) {
+      result.errors.push({
+        code: ICEErrorCode.INVALID_SEQUENCE,
+        message: 'Checksum must be 2 digits',
+      });
+      return result;
+    }
+
+    // Valid ICE
+    result.isValid = true;
+    result.metadata = {
+      company,
+      establishments,
+      checksum,
+    };
+
+    return result;
+  } else {
+    // TODO probably unreachable. Refactor.
+  }
+}

--- a/test/validators/company.spec.ts
+++ b/test/validators/company.spec.ts
@@ -1,0 +1,42 @@
+import { validateICE } from '../../src/validators/company'; // TODO import from src directly
+
+describe('ICE Validator', () => {
+  describe('validateICE', () => {
+    test('should validate correct ICEs', () => {
+      const validICEs = [
+        '001663252000092',
+        '001436361000017',
+        '000193552000068',
+        '000029979000032',
+      ];
+
+      validICEs.forEach(ice => {
+        const result = validateICE(ice);
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+      });
+    });
+
+    test('should reject invalid ICEs', () => {
+      const invalidICEs = [
+        '', // empty
+        '123456890000571234', // too many digits (>15)
+        '123456', // not enough digits
+        'ICE12345', // Characters
+        'BE12345689000057',
+        '123A5689000057',
+        // '000000000000000', // All zeros
+        '##12345689000057', // invalid characters
+        ':12345689000057',
+        '12345689000057*',
+        -1, // invalid type
+      ];
+
+      invalidICEs.forEach(ice => {
+        const result = validateICE(ice);
+        expect(result.isValid).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description of change

This is an attempt to address #1 
It implements validation of ICE of companies (a string of 15 digits), composed of a company code, establishments and a checksum. (Source: http://www.ompic.ma/fr/content/identifiant-commun-de-lentreprise)

Opted to create a new file named `company.ts`. It can hold ICE, Identifiant Fical, and other identifiers related to moroccan businesses.
I stuck to the structure used for the CIN, for validators, tests, and types.

@aitmiloud  I wanted some feedback from you before working further on the implementation. I am down to work on it, as well as others related to moroccan companies.

Newly added tests are passing. A test was failing on the main branch (`Bank Validators › isValidRIB › should validate a correct RIB`).

Fixes #1

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
